### PR TITLE
OpenMp parallel scheduler

### DIFF
--- a/src/operations/eavlMapOp.h
+++ b/src/operations/eavlMapOp.h
@@ -19,7 +19,7 @@ struct eavlMapOp_CPU
     template <class F, class IN, class OUT>
     static void call(int nitems, int, const IN inputs, OUT outputs, F &functor)
     {
-#pragma omp parallel for
+#pragma omp parallel for schedule(dynamic)
         for (int index = 0; index < nitems; ++index)
         {
             typename collecttype<IN>::const_type in(collect(index, inputs));


### PR DESCRIPTION
The default parallel for scheduler for openmp seems to be static and its slow.  Roba was previously benchmarking her volume rendering code that used a map operator and found that it got abysmal speedups, 1.5x for 2 cores, 2x for 3 cores...etc etc and this was the issue.  The dynamic scheduler may not be appropriate for all circumstances, so this pull request may not be necessary, but it highlights a question, should the default scheduler be kept at static? 